### PR TITLE
feat: add Docker setup for CI server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Git files
+.git
+.gitignore
+
+# IDE files
+.idea
+*.iml
+.vscode
+
+# Build artifacts (will be rebuilt in container)
+ci-app/target/
+*.class
+*.jar
+*.war
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Documentation
+README.md
+*.md
+
+# Docker files (no need to copy into image)
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+# Test files
+ci-app/src/test/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Maven
 target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Multi-stage build for Java CI Server
+# Stage 1: Build the application
+FROM maven:3.9-eclipse-temurin-25 AS build
+
+WORKDIR /build
+
+# Copy the entire ci-app directory
+COPY ci-app/ ./
+
+# Build the application
+RUN mvn clean package -DskipTests
+
+# Stage 2: Runtime
+FROM eclipse-temurin:25-jre
+
+WORKDIR /app
+
+# Copy the JAR from build stage
+COPY --from=build /build/target/*.jar app.jar
+
+# Expose port 8080 (internal container port)
+EXPOSE 8080
+
+# Set JVM options for memory management
+ENV JAVA_OPTS="-Xmx512m -Xms256m"
+
+# Run the application
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  ci-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: ci-server-group8
+    ports:
+      # Host:container — app always listens on 8080 inside container.
+      # Use 8080:8080 locally; on KTH shared machines use 8008:8080 (port 8000+group#).
+      - "8080:8080"
+    environment:
+      - JAVA_OPTS=-Xmx512m -Xms256m
+    restart: unless-stopped
+    networks:
+      - ci-network
+
+networks:
+  ci-network:
+    driver: bridge


### PR DESCRIPTION
- Add multi-stage Dockerfile with Java 25
- Add docker-compose.yml for local development
- Add .dockerignore to optimize build context
- Move .gitignore to repository root

## Docker

### Prerequisites

- [Docker](https://docs.docker.com/get-docker/) and Docker Compose installed.

### Build and run

From the repository root:

# Build and start (foreground; logs in terminal)

``` bash
docker compose up --build
```

# Or build and start in background
```bash
docker compose up --build -d
```

# stop
```
docker compose down
```