### PR TITLE
test: stop CI tests from rerunning Maven

### DIFF
--- a/ci-app/src/main/java/com/group8/ContinuousIntegrationServer.java
+++ b/ci-app/src/main/java/com/group8/ContinuousIntegrationServer.java
@@ -20,12 +20,12 @@ import org.json.JSONObject;
 public class ContinuousIntegrationServer extends AbstractHandler {
 
     /**
-     * Hook for triggering the CI pipeline. In production this delegates to
-     * {@link CIrunner}, but tests can override this method (in a subclass) to
-     * avoid spawning external Maven processes.
+     * Hook for triggering the CI pipeline and producing a {@link BuildRecord}.
+     * In production this delegates to {@link CIrunner}, but tests can override
+     * this method (in a subclass) to avoid spawning external Maven processes.
      */
-    protected void triggerCI(String cloneURL, String ref, String sha) {
-        CIrunner.triggerCI(cloneURL, ref, sha);
+    protected BuildRecord triggerCI(String cloneURL, String ref, String sha) {
+        return CIrunner.triggerCI(cloneURL, ref, sha);
     }
 
     private final BuildHistoryManager historyManager = new BuildHistoryManager();
@@ -86,7 +86,7 @@ public class ContinuousIntegrationServer extends AbstractHandler {
                         writer.println("CI started for " + ref + ".");
 
                         // trigger the actual CI !!!
-                        BuildRecord record = CIrunner.triggerCI(cloneURL, ref, sha);
+                        BuildRecord record = triggerCI(cloneURL, ref, sha);
                         historyManager.saveBuild(record);
                     } else {
                         System.out.println("Not an assessment/main branch. Ignore.");

--- a/ci-app/src/test/java/com/group8/ContinuousIntegrationServerTest.java
+++ b/ci-app/src/test/java/com/group8/ContinuousIntegrationServerTest.java
@@ -28,17 +28,15 @@ class ContinuousIntegrationServerTest {
      */
     private static class TestContinuousIntegrationServer extends ContinuousIntegrationServer {
         boolean ciTriggered = false;
-        String lastCloneURL;
         String lastRef;
-        String lastSha;
 
         @Override
-        protected void triggerCI(String cloneURL, String ref, String sha) {
+        protected BuildRecord triggerCI(String cloneURL, String ref, String sha) {
             this.ciTriggered = true;
-            this.lastCloneURL = cloneURL;
             this.lastRef = ref;
-            this.lastSha = sha;
-            // Do NOT call CIrunner.triggerCI here – unit tests should stay fast and side‑effect free.
+            // Do NOT call CIrunner.triggerCI here – unit tests should stay fast and
+            // side‑effect free.
+            return new BuildRecord(sha, "SUCCESS", System.currentTimeMillis(), "stub build from test");
         }
     }
 
@@ -113,6 +111,12 @@ class ContinuousIntegrationServerTest {
         assertTrue(
                 responseWriter.toString().toLowerCase().contains("assessment"),
                 () -> "Expected assessment branch handling, but got: " + responseWriter);
+
+        // Ensure CI trigger hook was called with correct ref
+        assertTrue(ciServer.ciTriggered, "Expected CI to be triggered for assessment branch");
+        assertTrue(
+                "refs/heads/assessment".equals(ciServer.lastRef),
+                () -> "Expected lastRef to be refs/heads/assessment but was: " + ciServer.lastRef);
     }
 
     @Test
@@ -134,6 +138,12 @@ class ContinuousIntegrationServerTest {
                 responseWriter.toString().toLowerCase().contains("refs/heads/main")
                         || responseWriter.toString().toLowerCase().contains("ci started for"),
                 () -> "Expected main branch handling, but got: " + responseWriter);
+
+        // Ensure CI trigger hook was called with correct ref
+        assertTrue(ciServer.ciTriggered, "Expected CI to be triggered for main branch");
+        assertTrue(
+                "refs/heads/main".equals(ciServer.lastRef),
+                () -> "Expected lastRef to be refs/heads/main but was: " + ciServer.lastRef);
     }
 
     @Test


### PR DESCRIPTION
Problem: ContinuousIntegrationServerTest was calling the real CIrunner.triggerCI, so on GitHub Actions the test started a full CI run (clone + mvn test), which then triggered the webhook again, causing a recursive loop and “stuck” builds.


Fix: Introduced a triggerCI(...) hook in ContinuousIntegrationServer that returns a BuildRecord, and in tests we subclass the server to override this hook and return a stub BuildRecord (no git/mvn). Production still runs the real CI; tests now only simulate it.

Closes #45 